### PR TITLE
Allow option for self signed certificates

### DIFF
--- a/lib/contract/hook/reduce.js
+++ b/lib/contract/hook/reduce.js
@@ -20,7 +20,7 @@ module.exports = (variables, hook, done) => {
     url: compileUrl(url, variables),
     timeout: hook.request.timeout,
     headers: compileHeaders(hook.request.headers, variables),
-    rejectUnauthorized: hook.request.rejectUnauthorized === false? false : true
+    rejectUnauthorized: hook.request.rejectUnauthorized !== false
   }
 
   _request.body = formatBody(hook.request.body, variables)

--- a/lib/contract/hook/reduce.js
+++ b/lib/contract/hook/reduce.js
@@ -19,7 +19,8 @@ module.exports = (variables, hook, done) => {
     method: hook.request.method,
     url: compileUrl(url, variables),
     timeout: hook.request.timeout,
-    headers: compileHeaders(hook.request.headers, variables)
+    headers: compileHeaders(hook.request.headers, variables),
+    rejectUnauthorized: hook.request.rejectUnauthorized === false? false : true
   }
 
   _request.body = formatBody(hook.request.body, variables)

--- a/lib/request/map.js
+++ b/lib/request/map.js
@@ -11,6 +11,7 @@ const mapRequest = (request, testUrl) => {
   if (request.headers)  { parsedRequest.headers = request.headers }
   if (request.body)     { parsedRequest.body = request.body }
   if (request.timeout)  { parsedRequest.timeout = request.timeout }
+  if (request.rejectUnauthorized === false)  { parsedRequest.rejectUnauthorized = request.rejectUnauthorized }
 
   return parsedRequest
 }

--- a/lib/request/map.js
+++ b/lib/request/map.js
@@ -11,7 +11,7 @@ const mapRequest = (request, testUrl) => {
   if (request.headers)  { parsedRequest.headers = request.headers }
   if (request.body)     { parsedRequest.body = request.body }
   if (request.timeout)  { parsedRequest.timeout = request.timeout }
-  if (request.rejectUnauthorized === false)  { parsedRequest.rejectUnauthorized = request.rejectUnauthorized }
+  parsedRequest.rejectUnauthorized = request.rejectUnauthorized !== false
 
   return parsedRequest
 }

--- a/lib/request/map.spec.js
+++ b/lib/request/map.spec.js
@@ -16,13 +16,13 @@ describe('mapRequest', function () {
     it('should populate rejectUnauthorized with true when set to true', function () {
       request.rejectUnauthorized = true
       const parsedRequest = mapRequest(request, testUrl)
-      expect(request.rejectUnauthorized).to.be.equal(true);
+      expect(parsedRequest.rejectUnauthorized).to.be.equal(true)
     })
 
     it('should populate rejectUnauthorized with false when set to false', function () {
       request.rejectUnauthorized = false
       const parsedRequest = mapRequest(request, testUrl)
-      expect(request.rejectUnauthorized).to.be.equal(false)
+      expect(parsedRequest.rejectUnauthorized).to.be.equal(false)
     })
   })
 

--- a/lib/request/map.spec.js
+++ b/lib/request/map.spec.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const mapRequest = require('./map')
+
+describe('mapRequest', function () {
+  describe('parsed requests gets populated', function () {
+    let request = {}
+    let testUrl = 'http://www.test.com';
+    
+    it('should populate rejectUnauthorized with true when not provided', function () {
+      request = {}
+      const parsedRequest = mapRequest(request, testUrl)
+      expect(parsedRequest.rejectUnauthorized).to.be.equal(true)
+    })
+
+    it('should populate rejectUnauthorized with true when set to true', function () {
+      request.rejectUnauthorized = true
+      const parsedRequest = mapRequest(request, testUrl)
+      expect(request.rejectUnauthorized).to.be.equal(true);
+    })
+
+    it('should populate rejectUnauthorized with false when set to false', function () {
+      request.rejectUnauthorized = false
+      const parsedRequest = mapRequest(request, testUrl)
+      expect(request.rejectUnauthorized).to.be.equal(false)
+    })
+  })
+
+})

--- a/lib/request/map.spec.js
+++ b/lib/request/map.spec.js
@@ -13,17 +13,12 @@ describe('mapRequest', function () {
       expect(parsedRequest.rejectUnauthorized).to.be.equal(true)
     })
 
-    it('should populate rejectUnauthorized with true when set to true', function () {
-      request.rejectUnauthorized = true
-      const parsedRequest = mapRequest(request, testUrl)
-      expect(parsedRequest.rejectUnauthorized).to.be.equal(true)
-    })
-
     it('should populate rejectUnauthorized with false when set to false', function () {
       request.rejectUnauthorized = false
       const parsedRequest = mapRequest(request, testUrl)
       expect(parsedRequest.rejectUnauthorized).to.be.equal(false)
     })
+
   })
 
 })

--- a/lib/validate/hook.js
+++ b/lib/validate/hook.js
@@ -23,7 +23,8 @@ const hookSchema = Joi.object().keys({
     method: Joi.string().valid(httpVerbs).optional(),
     headers: Joi.object().optional(),
     body: Joi.alternatives([Joi.string(), Joi.object(), Joi.array()]).optional(),
-    timeout: Joi.number().integer().optional()
+    timeout: Joi.number().integer().optional(),
+    rejectUnauthorized: Joi.boolean().optional()
   }).required(),
   response: Joi.object().keys({
     statusCode: Joi.number().integer().valid(httpStatusCodes).required()

--- a/lib/validate/hook.spec.js
+++ b/lib/validate/hook.spec.js
@@ -132,6 +132,15 @@ describe('validateHook', function (t) {
     expect(validateHook(hook)).to.eql(expected)
   })
 
+  it('should fail when given a hook with a non-boolean rejectUnauthorized field', function () {
+    hook.request.method = 'GET'
+    hook.request.rejectUnauthorized = 123
+    hook.variables = {}
+    expected = { valid: false, error: { name: 'ValidationError', message: '"rejectUnauthorized" must be a boolean' } }
+    expect(validateHook(hook)).to.eql(expected)
+    hook.request.rejectUnauthorized = false
+  })
+  
   it('should pass when given a valid hook', function () {
     hook.variables = {}
     expected = { valid: true, error: null }

--- a/lib/validate/request.js
+++ b/lib/validate/request.js
@@ -14,7 +14,8 @@ const requestSchema = Joi.object().keys({
   method: Joi.string().valid(httpVerbs).default('GET').optional(),
   headers: Joi.object().optional(),
   body: Joi.alternatives([Joi.string(), Joi.object(), Joi.array()]).optional(),
-  timeout: Joi.number().integer().optional()
+  timeout: Joi.number().integer().optional(),
+  rejectUnauthorized: Joi.boolean().optional()
 })
 
 module.exports = validateJoi(requestSchema)

--- a/lib/validate/request.spec.js
+++ b/lib/validate/request.spec.js
@@ -50,6 +50,14 @@ describe('validateRequest', function (t) {
     expect(validateRequest(request)).to.be.deep.equal(expected)
   })
 
+  it('should fail when given a request object with a non-bool rejectUnauthorized', function () {
+    request.rejectUnauthorized = 123
+    request.body = 'body'
+    expected = { valid: false, error: { name: 'ValidationError', message: '"rejectUnauthorized" must be a boolean' } }
+    expect(validateRequest(request)).to.be.deep.equal(expected)
+    request.rejectUnauthorized = true
+  })
+
   it('should pass when given a request object with string body', function () {
     request.body = 'body'
     expected = { valid: true, error: null }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jackal",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Consumer Driven Contracts Service",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
When creating tests against urls that have self signed certificates tests fail, the error being returned is  `unable to get local issuer certificate`.

A new option **rejectUnauthorized** can be passed as part of the request object, setting it to false bypasses ssl validations:

`"request":{ ...
          "rejectUnauthorized": false,
...}`

on both, **hooks** and **main** **requests** no error related to certificates should be returned.

